### PR TITLE
Add requirement for SPARQLWrapper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==1.0.3
 Flask-Cors==3.0.7
 rdflib==4.2.2
+SPARQLWrapper==1.8.4


### PR DESCRIPTION
The requirement for SPARQLWrapper was missing in the `requirements.txt`.